### PR TITLE
Load ORS API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # saferoute-ai
 "AI agent that predicts travel risk in Israel during missile threats"
+
+## Setup
+
+Set the `ORS_API_KEY` environment variable with your OpenRouteService API key before running the script:
+
+```bash
+export ORS_API_KEY=your_api_key
+python saferoute.py
+```

--- a/saferoute.py
+++ b/saferoute.py
@@ -10,9 +10,9 @@ This script will:
 4. Return a natural-language safety summary
 """
 import requests
+import os
 
-# Replace this with your actual ORS API key
-ORS_API_KEY = "5b3ce3597851110001cf624856f5924055544c8faabb05aec29d7ac0"
+ORS_API_KEY = os.getenv("ORS_API_KEY")
 
 from math import radians, sin, cos, sqrt, atan2
 
@@ -36,8 +36,6 @@ def load_shelters(path="shelters.json"):
 import json
 import requests
 from math import radians, sin, cos, sqrt, atan2
-
-ORS_API_KEY = "YOUR_API_KEY"
 
 def haversine_distance(lat1, lon1, lat2, lon2):
     ...


### PR DESCRIPTION
## Summary
- load ORS API key from `ORS_API_KEY` environment variable
- document how to set `ORS_API_KEY` before running the script

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6852ec4152688325ab4920812ea07ce5