### PR TITLE
Improve docs and script API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # saferoute-ai
 "AI agent that predicts travel risk in Israel during missile threats"
+
+## Requirements
+
+* Python 3
+* [`requests`](https://pypi.org/project/requests/)
+
+Install the dependency with:
+
+```bash
+pip install requests
+```
+
+## API Key
+
+`saferoute.py` calls the OpenRouteService API and needs an API key. The
+script reads the key from the `ORS_API_KEY` environment variable. Set it
+before running the script:
+
+```bash
+export ORS_API_KEY=your-api-key-here
+```
+
+Alternatively, you can edit the `ORS_API_KEY` constant in `saferoute.py`.
+
+## Usage
+
+Run the script with:
+
+```bash
+python saferoute.py
+```

--- a/saferoute.py
+++ b/saferoute.py
@@ -1,7 +1,6 @@
 # SafeRoute AI - MVP Travel Risk Agent
 # Author: Yoav A.
 # Version: 0.1
-
 """
 This script will:
 1. Accept origin, destination, and travel time
@@ -9,49 +8,40 @@ This script will:
 3. Analyze exposure to risk (e.g., distance from bomb shelters)
 4. Return a natural-language safety summary
 """
+
+import os
+import json
 import requests
-
-# Replace this with your actual ORS API key
-ORS_API_KEY = "5b3ce3597851110001cf624856f5924055544c8faabb05aec29d7ac0"
-
 from math import radians, sin, cos, sqrt, atan2
 
+# Read the OpenRouteService API key from the environment. If not provided,
+# the placeholder string "YOUR_API_KEY" is used and API calls will fail.
+ORS_API_KEY = os.getenv("ORS_API_KEY", "YOUR_API_KEY")
+
+
 def haversine_distance(lat1, lon1, lat2, lon2):
-    """
-    Calculates distance in meters between two lat/lon points.
-    """
+    """Calculate distance in meters between two lat/lon points."""
     R = 6371000  # Earth radius in meters
     phi1 = radians(lat1)
     phi2 = radians(lat2)
     d_phi = radians(lat2 - lat1)
     d_lambda = radians(lon2 - lon1)
 
-    a = sin(d_phi/2)**2 + cos(phi1) * cos(phi2) * sin(d_lambda/2)**2
+    a = sin(d_phi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(d_lambda / 2) ** 2
     c = 2 * atan2(sqrt(a), sqrt(1 - a))
     return R * c
 
+
 def load_shelters(path="shelters.json"):
+    """Load shelter locations from a JSON file."""
     with open(path, "r") as f:
         return json.load(f)
-import json
-import requests
-from math import radians, sin, cos, sqrt, atan2
 
-ORS_API_KEY = "YOUR_API_KEY"
-
-def haversine_distance(lat1, lon1, lat2, lon2):
-    ...
-
-def load_shelters(path="shelters.json"):
-    ...
 
 def count_exposed_segments(route, shelters, threshold_meters=1000):
-    """
-    Counts how many route points are farther than `threshold_meters` from the nearest shelter.
-    """
+    """Count how many route points are farther than the threshold from a shelter."""
     exposed = 0
-    for point in route:
-        lon, lat = point
+    for lon, lat in route:
         min_distance = float("inf")
         for shelter in shelters:
             dist = haversine_distance(lat, lon, shelter["lat"], shelter["lon"])
@@ -61,39 +51,13 @@ def count_exposed_segments(route, shelters, threshold_meters=1000):
             exposed += 1
     return exposed
 
+
 def fetch_route(start_coords, end_coords):
-    ...
-    
-def assess_risk(start_location, end_location, travel_time):
-    ...
-
-def assess_risk(start_location, end_location, travel_time):
-    """
-    Core function for route risk assessment.
-    For now, this is a placeholder that returns mock risk levels.
-    """
-    print(f"Starting location: {start_location}")
-    print(f"Destination: {end_location}")
-    print(f"Travel time: {travel_time}")
-
-    # TODO: Add route lookup
-    # TODO: Add shelter proximity logic
-    # TODO: Add risk scoring
-
-    return {
-        "risk_level": "MODERATE",
-        "details": "Between Be'er Sheva and Mitzpe Ramon, there is a 40km stretch with no shelter access."
-    }
-def fetch_route(start_coords, end_coords):
-    """
-    Fetch driving route from OpenRouteService.
-    Input: [lon, lat] for start and end
-    Returns: list of [lon, lat] coordinates along the route
-    """
+    """Fetch driving route from OpenRouteService."""
     url = "https://api.openrouteservice.org/v2/directions/driving-car"
     headers = {
         "Authorization": ORS_API_KEY,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
     body = {
         "coordinates": [start_coords, end_coords]
@@ -103,13 +67,28 @@ def fetch_route(start_coords, end_coords):
     if response.status_code == 200:
         data = response.json()
         return data["features"][0]["geometry"]["coordinates"]
-    else:
-        print("Route fetch failed:", response.status_code, response.text)
-        return []
+    print("Route fetch failed:", response.status_code, response.text)
+    return []
 
-# Example test
+
+def assess_risk(start_location, end_location, travel_time):
+    """Placeholder risk assessment function."""
+    print(f"Starting location: {start_location}")
+    print(f"Destination: {end_location}")
+    print(f"Travel time: {travel_time}")
+
+    # TODO: Add route lookup and shelter proximity logic.
+    return {
+        "risk_level": "MODERATE",
+        "details": (
+            "Between Be'er Sheva and Mitzpe Ramon, there is a 40km stretch with "
+            "no shelter access."
+        ),
+    }
+
+
 if __name__ == "__main__":
-    # Test route from Tel Aviv to Mitzpe Ramon
+    # Example test
     route = fetch_route([34.7818, 32.0853], [34.8016, 30.6072])
     print(f"Route contains {len(route)} segments.")
 


### PR DESCRIPTION
## Summary
- document requests dependency
- explain `ORS_API_KEY` setup
- provide example command to run the script
- load API key from environment and remove duplicate code

## Testing
- `python saferoute.py` *(fails: No module named 'requests')*
- `pip install requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec7278548325ad7f2b6d34725283